### PR TITLE
BugFix: Error Throw on App Resizing

### DIFF
--- a/ProgressKeeper/MainForm.Designer.cs
+++ b/ProgressKeeper/MainForm.Designer.cs
@@ -30,12 +30,12 @@ namespace ProgressKeeper
         private void InitializeComponent()
         {
             this.DateTimePicker1 = new System.Windows.Forms.DateTimePicker();
-            this.TabHistory = new System.Windows.Forms.TabControl();
+            this.TabControl1 = new System.Windows.Forms.TabControl();
             this.TabAddProgress = new System.Windows.Forms.TabPage();
             this.InsertProgress = new System.Windows.Forms.Button();
             this.richTextBox1 = new System.Windows.Forms.RichTextBox();
-            this.tabShowHistory = new System.Windows.Forms.TabPage();
-            this.TabHistory.SuspendLayout();
+            this.TabShowHistory = new System.Windows.Forms.TabPage();
+            this.TabControl1.SuspendLayout();
             this.TabAddProgress.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -48,18 +48,18 @@ namespace ProgressKeeper
             this.DateTimePicker1.TabIndex = 2;
             this.DateTimePicker1.ValueChanged += new System.EventHandler(this.DateTimePicker1_ValueChanged);
             // 
-            // TabHistory
+            // TabControl1
             // 
-            this.TabHistory.Appearance = System.Windows.Forms.TabAppearance.FlatButtons;
-            this.TabHistory.Controls.Add(this.TabAddProgress);
-            this.TabHistory.Controls.Add(this.tabShowHistory);
-            this.TabHistory.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.TabHistory.Location = new System.Drawing.Point(0, 0);
-            this.TabHistory.Name = "TabHistory";
-            this.TabHistory.SelectedIndex = 0;
-            this.TabHistory.Size = new System.Drawing.Size(774, 441);
-            this.TabHistory.TabIndex = 3;
-            this.TabHistory.SelectedIndexChanged += new System.EventHandler(this.TabControl1_SelectedIndexChanged);
+            this.TabControl1.Appearance = System.Windows.Forms.TabAppearance.FlatButtons;
+            this.TabControl1.Controls.Add(this.TabAddProgress);
+            this.TabControl1.Controls.Add(this.TabShowHistory);
+            this.TabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.TabControl1.Location = new System.Drawing.Point(0, 0);
+            this.TabControl1.Name = "TabControl1";
+            this.TabControl1.SelectedIndex = 0;
+            this.TabControl1.Size = new System.Drawing.Size(774, 441);
+            this.TabControl1.TabIndex = 3;
+            this.TabControl1.SelectedIndexChanged += new System.EventHandler(this.TabControl1_SelectedIndexChanged);
             // 
             // TabAddProgress
             // 
@@ -92,15 +92,15 @@ namespace ProgressKeeper
             this.richTextBox1.TabIndex = 3;
             this.richTextBox1.Text = "";
             // 
-            // tabShowHistory
+            // TabShowHistory
             // 
-            this.tabShowHistory.Location = new System.Drawing.Point(4, 27);
-            this.tabShowHistory.Name = "tabShowHistory";
-            this.tabShowHistory.Padding = new System.Windows.Forms.Padding(3);
-            this.tabShowHistory.Size = new System.Drawing.Size(766, 410);
-            this.tabShowHistory.TabIndex = 1;
-            this.tabShowHistory.Text = "History";
-            this.tabShowHistory.UseVisualStyleBackColor = true;
+            this.TabShowHistory.Location = new System.Drawing.Point(4, 27);
+            this.TabShowHistory.Name = "TabShowHistory";
+            this.TabShowHistory.Padding = new System.Windows.Forms.Padding(3);
+            this.TabShowHistory.Size = new System.Drawing.Size(766, 410);
+            this.TabShowHistory.TabIndex = 1;
+            this.TabShowHistory.Text = "History";
+            this.TabShowHistory.UseVisualStyleBackColor = true;
             // 
             // MainForm
             // 
@@ -108,14 +108,14 @@ namespace ProgressKeeper
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(774, 441);
-            this.Controls.Add(this.TabHistory);
+            this.Controls.Add(this.TabControl1);
             this.MinimumSize = new System.Drawing.Size(400, 240);
             this.Name = "MainForm";
             this.Text = "Progress Keeper";
             this.Load += new System.EventHandler(this.MainForm_Load);
             this.ResizeBegin += new System.EventHandler(this.MainForm_ResizeBegin);
             this.SizeChanged += new System.EventHandler(this.MainForm_SizeChanged);
-            this.TabHistory.ResumeLayout(false);
+            this.TabControl1.ResumeLayout(false);
             this.TabAddProgress.ResumeLayout(false);
             this.ResumeLayout(false);
 
@@ -126,7 +126,7 @@ namespace ProgressKeeper
         private System.Windows.Forms.TabControl TabControl1;
         private System.Windows.Forms.TabPage TabAddProgress;
         private System.Windows.Forms.TabControl TabHistory;
-        private System.Windows.Forms.TabPage tabShowHistory;
+        private System.Windows.Forms.TabPage TabShowHistory;
         private System.Windows.Forms.RichTextBox richTextBox1;
         private System.Windows.Forms.Button InsertProgress;
     }


### PR DESCRIPTION
BugFix: Tab Control wrong name, causes the application throw error on resizing the application.